### PR TITLE
Use a fork of rquickjs with a "wasi" patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,8 +2198,7 @@ dependencies = [
 [[package]]
 name = "rquickjs"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7f63201fa6f2ff8173e4758ea552549d687d8f63003361a8b5c50f7c446ded"
+source = "git+https://github.com/saulecabrera/rquickjs?branch=wasi-patch#d90b4221845e798effe5dedd6ea6ac746858cb9e"
 dependencies = [
  "rquickjs-core",
 ]
@@ -2207,8 +2206,7 @@ dependencies = [
 [[package]]
 name = "rquickjs-core"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad00eeddc0f88af54ee202c8385fb214fe0423897c056a7df8369fb482e3695"
+source = "git+https://github.com/saulecabrera/rquickjs?branch=wasi-patch#d90b4221845e798effe5dedd6ea6ac746858cb9e"
 dependencies = [
  "rquickjs-sys",
 ]
@@ -2216,8 +2214,7 @@ dependencies = [
 [[package]]
 name = "rquickjs-sys"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120dbbc3296de9b96de8890091635d46f3506cd38b4e8f21800c386c035d64fa"
+source = "git+https://github.com/saulecabrera/rquickjs?branch=wasi-patch#d90b4221845e798effe5dedd6ea6ac746858cb9e"
 dependencies = [
  "cc",
 ]

--- a/crates/javy/Cargo.toml
+++ b/crates/javy/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["wasm"]
 
 [dependencies]
 anyhow = { workspace = true }
-rquickjs = { version = "0.5.1", features = ["array-buffer"] }
+rquickjs = { git = "https://github.com/saulecabrera/rquickjs", branch = "wasi-patch", features = ["array-buffer"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 serde-transcode = { version = "1.1", optional = true }


### PR DESCRIPTION
This commit introduces a fork of rquickjs, which introduces a "wasi" patch that includes the following performance improvements:

- `no-op` on `__JS_FreeValueRT`, this function gets called frequently, and is a considerable overhead for short-lived WASI/Wasm programs
- Exclude the `error_column_number.patch` which includes a function (utf8_str_len) to provide better diagnostics in JSON parsing, which also introduces a considerable overhead in execution time (~10%)

## Description of the change

## Why am I making this change?

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
