### PR TITLE
Introduce `Javy.JSON`

### DIFF
--- a/crates/apis/Cargo.toml
+++ b/crates/apis/Cargo.toml
@@ -18,4 +18,4 @@ text_encoding = []
 [dependencies]
 anyhow = { workspace = true }
 fastrand = { version = "2.0.2", optional = true }
-javy = { workspace = true }
+javy = { workspace = true, features = ["json"] }

--- a/crates/apis/src/json/json.js
+++ b/crates/apis/src/json/json.js
@@ -1,0 +1,27 @@
+(function () {
+    const __javy_json_parse = globalThis.__javy_json_parse;
+    const __javy_json_stringify = globalThis.__javy_json_stringify;
+    const __javy_json_from_stdin = globalThis.__javy_json_from_stdin;
+    const __javy_json_to_stdout = globalThis.__javy_json_to_stdout;
+
+    globalThis.Javy.JSON = {
+      parse(v) {
+        return __javy_json_parse(v);
+      },
+      stringify(v) {
+        return __javy_json_stringify(v);
+      },
+      fromStdin() {
+        return __javy_json_from_stdin();
+      },
+      toStdout(v) {
+        return __javy_json_to_stdout(v);
+      }
+    };
+
+
+    Reflect.deleteProperty(globalThis, "__javy_json_parse");
+    Reflect.deleteProperty(globalThis, "__javy_json_stringify");
+    Reflect.deleteProperty(globalThis, "__javy_json_from_stdin");
+    Reflect.deleteProperty(globalThis, "__javy_json_to_stdout");
+})();

--- a/crates/apis/src/json/mod.rs
+++ b/crates/apis/src/json/mod.rs
@@ -1,0 +1,89 @@
+use crate::{APIConfig, JSApiSet};
+use anyhow::Error;
+use javy::{
+    hold, hold_and_release, json,
+    quickjs::{Function, String as JSString, Value},
+    Args,
+};
+use std::io::{Read, Write};
+
+pub struct Json;
+
+impl JSApiSet for Json {
+    fn register(&self, runtime: &javy::Runtime, _: &APIConfig) -> anyhow::Result<()> {
+        runtime.context().with(|this| {
+            let globals = this.globals();
+
+            globals.set(
+                "__javy_json_parse",
+                Function::new(this.clone(), |cx, args| {
+                    let (cx, args) = hold_and_release!(cx, args);
+                    parse(hold!(cx, args))
+                }),
+            )?;
+
+            globals.set(
+                "__javy_json_stringify",
+                Function::new(this.clone(), |cx, args| {
+                    let (cx, args) = hold_and_release!(cx, args);
+                    stringify_value(hold!(cx, args))
+                }),
+            )?;
+
+            globals.set(
+                "__javy_json_from_stdin",
+                Function::new(this.clone(), |cx, args| {
+                    let (cx, args) = hold_and_release!(cx, args);
+                    from_stdin(hold!(cx, args))
+                }),
+            )?;
+
+            globals.set(
+                "__javy_json_to_stdout",
+                Function::new(this.clone(), |cx, args| {
+                    let (cx, args) = hold_and_release!(cx, args);
+                    to_stdout(hold!(cx, args))
+                }),
+            )?;
+
+            this.eval(include_str!("json.js"))?;
+            Ok::<_, Error>(())
+        })?;
+
+        Ok(())
+    }
+}
+
+fn parse(a: Args<'_>) -> Value<'_> {
+    let (cx, args) = a.release();
+
+    let string = args[0].as_string().unwrap().to_string().unwrap();
+    json::transcode_input(cx.clone(), &string.as_bytes()).unwrap()
+}
+
+fn stringify_value(a: Args<'_>) -> Value<'_> {
+    let (cx, args) = a.release();
+
+    let bytes = json::transcode_output(args[0].clone()).unwrap();
+
+    let str = std::str::from_utf8(&bytes).unwrap();
+    let js_str = JSString::from_str(cx.clone(), str).unwrap();
+
+    Value::from(js_str)
+}
+
+fn from_stdin(a: Args<'_>) -> Value<'_> {
+    let (cx, _) = a.release();
+    let mut bytes = Vec::with_capacity(10000);
+    let mut fd = std::io::stdin();
+    fd.read_to_end(&mut bytes).unwrap();
+
+    json::transcode_input(cx.clone(), &bytes).unwrap()
+}
+
+fn to_stdout(a: Args<'_>) {
+    let (_, args) = a.release();
+    let mut fd = std::io::stdout();
+    let out = json::transcode_output(args[0].clone()).unwrap();
+    fd.write_all(&out).unwrap();
+}

--- a/crates/apis/src/lib.rs
+++ b/crates/apis/src/lib.rs
@@ -61,6 +61,8 @@ mod stream_io;
 #[cfg(feature = "text_encoding")]
 mod text_encoding;
 
+mod json;
+
 pub(crate) trait JSApiSet {
     fn register(&self, runtime: &Runtime, config: &APIConfig) -> Result<()>;
 }
@@ -85,5 +87,6 @@ pub fn add_to_runtime(runtime: &Runtime, config: APIConfig) -> Result<()> {
     stream_io::StreamIO.register(runtime, &config)?;
     #[cfg(feature = "text_encoding")]
     text_encoding::TextEncoding.register(runtime, &config)?;
+    json::Json.register(runtime, &config)?;
     Ok(())
 }


### PR DESCRIPTION
This commint introduces the `Javy.JSON` namespace, which includes non-standardard JSON functions for working with JSON. One can think of this functions as a fast-path implementation between JS/Rust.

## Description of the change

## Why am I making this change?

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
