### PR TITLE
Include debug information in the generated module

### DIFF
--- a/crates/cli/src/wasm_generator/static.rs
+++ b/crates/cli/src/wasm_generator/static.rs
@@ -137,7 +137,7 @@ fn optimize_wasm(wasm: &[u8]) -> Result<Vec<u8>> {
 
     OptimizationOptions::new_opt_level_3() // Aggressively optimize for speed.
         .shrink_level(ShrinkLevel::Level0) // Don't optimize for size at the expense of performance.
-        .debug_info(false)
+        .debug_info(true)
         .run(&tempfile_path, &tempfile_path)?;
 
     Ok(fs::read(&tempfile_path)?)

--- a/crates/cli/src/wasm_generator/transform.rs
+++ b/crates/cli/src/wasm_generator/transform.rs
@@ -36,7 +36,7 @@ impl CustomSection for SourceCodeSection {
 
 pub fn module_config() -> ModuleConfig {
     let mut config = ModuleConfig::new();
-    config.generate_name_section(false);
+    config.generate_name_section(true);
     config
 }
 


### PR DESCRIPTION
This commit ensures that the name section and debug info is kept in the module generated by running `javy compile <source>.wasm`, this makes it easier to profile QuickJS and any APIs implemented in Rust. 

Note: this behaviour should be made configurable if we want to port this change upstream.

## Description of the change

## Why am I making this change?

## Checklist

- [ ] I've updated the relevant CHANGELOG files if necessary. Changes to `javy-cli` and `javy-core` do not require updating CHANGELOG files.
- [ ] I've updated the relevant crate versions if necessary. [Versioning policy for library crates](https://github.com/bytecodealliance/javy/blob/main/docs/contributing.md#versioning-for-library-crates)
- [ ] I've updated documentation including crate documentation if necessary.
